### PR TITLE
feat: updating `cargo.toml` and `package.json` before version commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "quic"
-version = "0.0.1"
+version = "0.0.4-alpha.0"
 dependencies = [
  "boring",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic"
-version = "0.0.1"
+version = "0.0.3-alpha.0"
 authors = ["Roger Qiu <roger.qiu@polyhack.io>"]
 license-file = "LICENSE"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quic"
-version = "0.0.3-alpha.0"
+version = "0.0.4-alpha.0"
 authors = ["Roger Qiu <roger.qiu@polyhack.io>"]
 license-file = "LICENSE"
 edition = "2021"

--- a/benches/index.ts
+++ b/benches/index.ts
@@ -4,13 +4,13 @@ import fs from 'fs';
 import path from 'path';
 import si from 'systeminformation';
 import Stream1KB from './stream_1KB';
-// import Dummy from './dummy';
+// Import Dummy from './dummy';
 
 async function main(): Promise<void> {
   await fs.promises.mkdir(path.join(__dirname, 'results'), { recursive: true });
   // Running benches
   await Stream1KB();
-  // await Dummy();
+  // Await Dummy();
   const resultFilenames = await fs.promises.readdir(
     path.join(__dirname, 'results'),
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "@matrixai/quic",
-  "version": "0.0.3-alpha.0",
+  "version": "0.0.4-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matrixai/quic",
-      "version": "0.0.3-alpha.0",
+      "version": "0.0.4-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@matrixai/async-init": "^1.8.1",
         "@matrixai/async-locks": "^3.1.1",
         "@matrixai/errors": "^1.1.2",
         "@matrixai/logger": "^3.1.0",
-        "@matrixai/quic-darwin-arm64": "0.0.3-alpha.0",
-        "@matrixai/quic-darwin-x64": "0.0.3-alpha.0",
-        "@matrixai/quic-linux-x64": "0.0.3-alpha.0",
-        "@matrixai/quic-win32-x64": "0.0.3-alpha.0",
+        "@matrixai/quic-darwin-arm64": "0.0.4-alpha.0",
+        "@matrixai/quic-darwin-x64": "0.0.4-alpha.0",
+        "@matrixai/quic-linux-x64": "0.0.4-alpha.0",
+        "@matrixai/quic-win32-x64": "0.0.4-alpha.0",
         "@matrixai/resources": "^1.1.3",
         "@matrixai/workers": "^1.3.5",
         "ip-num": "^1.5.0"
@@ -58,10 +58,10 @@
         "typescript": "^4.5.2"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "0.0.3-alpha.0",
-        "@matrixai/quic-darwin-x64": "0.0.3-alpha.0",
-        "@matrixai/quic-linux-x64": "0.0.3-alpha.0",
-        "@matrixai/quic-win32-x64": "0.0.3-alpha.0"
+        "@matrixai/quic-darwin-arm64": "0.0.4-alpha.0",
+        "@matrixai/quic-darwin-x64": "0.0.4-alpha.0",
+        "@matrixai/quic-linux-x64": "0.0.4-alpha.0",
+        "@matrixai/quic-win32-x64": "0.0.4-alpha.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,22 @@
 {
   "name": "@matrixai/quic",
-  "version": "0.0.2-alpha.0",
+  "version": "0.0.3-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@matrixai/quic",
-      "version": "0.0.2-alpha.0",
+      "version": "0.0.3-alpha.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@matrixai/async-init": "^1.8.1",
         "@matrixai/async-locks": "^3.1.1",
         "@matrixai/errors": "^1.1.2",
         "@matrixai/logger": "^3.1.0",
+        "@matrixai/quic-darwin-arm64": "0.0.3-alpha.0",
+        "@matrixai/quic-darwin-x64": "0.0.3-alpha.0",
+        "@matrixai/quic-linux-x64": "0.0.3-alpha.0",
+        "@matrixai/quic-win32-x64": "0.0.3-alpha.0",
         "@matrixai/resources": "^1.1.3",
         "@matrixai/workers": "^1.3.5",
         "ip-num": "^1.5.0"
@@ -54,10 +58,10 @@
         "typescript": "^4.5.2"
       },
       "optionalDependencies": {
-        "@matrixai/quic-darwin-arm64": "0.0.1",
-        "@matrixai/quic-darwin-x64": "0.0.1",
-        "@matrixai/quic-linux-x64": "0.0.1",
-        "@matrixai/quic-win32-x64": "0.0.1"
+        "@matrixai/quic-darwin-arm64": "0.0.3-alpha.0",
+        "@matrixai/quic-darwin-x64": "0.0.3-alpha.0",
+        "@matrixai/quic-linux-x64": "0.0.3-alpha.0",
+        "@matrixai/quic-win32-x64": "0.0.3-alpha.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matrixai/quic",
-  "version": "0.0.3-alpha.0",
+  "version": "0.0.4-alpha.0",
   "bin": {
     "server": "dist/bin/server.js"
   },
@@ -40,10 +40,10 @@
     "ip-num": "^1.5.0"
   },
   "optionalDependencies": {
-    "@matrixai/quic-darwin-arm64": "0.0.3-alpha.0",
-    "@matrixai/quic-darwin-x64": "0.0.3-alpha.0",
-    "@matrixai/quic-linux-x64": "0.0.3-alpha.0",
-    "@matrixai/quic-win32-x64": "0.0.3-alpha.0"
+    "@matrixai/quic-darwin-arm64": "0.0.4-alpha.0",
+    "@matrixai/quic-darwin-x64": "0.0.4-alpha.0",
+    "@matrixai/quic-linux-x64": "0.0.4-alpha.0",
+    "@matrixai/quic-win32-x64": "0.0.4-alpha.0"
   },
   "devDependencies": {
     "@fast-check/jest": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "tsc -p ./tsconfig.build.json",
     "prebuild": "node ./scripts/prebuild.js",
     "build": "rimraf ./dist && tsc -p ./tsconfig.build.json",
-    "postversion": "node ./scripts/postversion.js",
+    "version": "node ./scripts/version.js",
     "prepublishOnly": "node ./scripts/prepublishOnly.js",
     "ts-node": "ts-node",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matrixai/quic",
-  "version": "0.0.2-alpha.0",
+  "version": "0.0.3-alpha.0",
   "bin": {
     "server": "dist/bin/server.js"
   },
@@ -40,10 +40,10 @@
     "ip-num": "^1.5.0"
   },
   "optionalDependencies": {
-    "@matrixai/quic-linux-x64": "0.0.1",
-    "@matrixai/quic-win32-x64": "0.0.1",
-    "@matrixai/quic-darwin-x64": "0.0.1",
-    "@matrixai/quic-darwin-arm64": "0.0.1"
+    "@matrixai/quic-darwin-arm64": "0.0.3-alpha.0",
+    "@matrixai/quic-darwin-x64": "0.0.3-alpha.0",
+    "@matrixai/quic-linux-x64": "0.0.3-alpha.0",
+    "@matrixai/quic-win32-x64": "0.0.3-alpha.0"
   },
   "devDependencies": {
     "@fast-check/jest": "^1.1.0",

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * This runs after `npm version` command.
- * This will update the `package.json` optional native dependencies
+ * This runs after `npm version` command updates the version but before changes are commited.
+ * This will update the `cargo.toml` version to match the new `package.json` verson.
+ * This will also update the `package.json` optional native dependencies
  * to match the same version as the version of this package.
  * This maintains the same version between this master package
  * and the optional native dependencies.
@@ -12,6 +13,9 @@
  * to prevent `npm` from attempting to download unpublished packages.
  */
 
+const process = require('process');
+const path = require('path');
+const fs = require('fs');
 const os = require('os');
 const childProcess = require('child_process');
 const packageJSON = require('../package.json');
@@ -20,6 +24,27 @@ const platform = os.platform();
 
 /* eslint-disable no-console */
 async function main() {
+
+  console.error(
+    'Updating the cargo.toml version to match new version',
+  );
+  const projectRoot = path.join(__dirname, '..');
+  const cargoTOMLPath = path.join(projectRoot, 'Cargo.toml');
+  const cargoTOML = await fs.promises.readFile(cargoTOMLPath, 'utf-8');
+  const cargoTOMLMatch = cargoTOML.match(/version\s*=\s*"(.*)"/);
+  const cargoTOMLUpdated = cargoTOML.replace(cargoTOMLMatch[0], `version = "${packageJSON.version}"`);
+  await fs.promises.writeFile(cargoTOMLPath, cargoTOMLUpdated, 'utf-8');
+
+  console.error(
+    'Staging changes in git',
+  );
+  childProcess.execFileSync('git', ['add', cargoTOMLPath], {
+    stdio: ['inherit', 'inherit', 'inherit'],
+    windowsHide: true,
+    encoding: 'utf-8',
+    shell: platform === 'win32' ? true : false,
+  });
+
   console.error(
     'Updating the package.json with optional native dependencies and package-lock.json',
   );


### PR DESCRIPTION
### Description

This PR adds a `version` script that updates the `cargo.toml` version to match the new `package.json` version when a `npm version` is run.

It also rolls the `postVersion` script into the `version` script. The changes from the `postVersion` script were not included in the tagged version commit.  

* Related #28

### Issues Fixed

* Fixes #28 

### Tasks
* [x] 1. Ensure that automatic changes to the version numbers in the `package.json` dependencies and `cargo.toml` file are updated with the new version from the `npm version` command. ensure that these changes are included in the tagged version commit.
* [x] 2. Ensure that there are no un-staged or un-commited changes that should be included in the commit.
* [x] 3. Verify this all works with a pre-release version.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
