### PR TITLE
Feat monitor fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-init": "^1.8.4",
         "@matrixai/async-locks": "^4.0.0",
-        "@matrixai/contexts": "^1.1.0",
+        "@matrixai/contexts": "^1.2.0",
         "@matrixai/errors": "^1.1.7",
         "@matrixai/logger": "^3.1.0",
         "@matrixai/resources": "^1.1.5",
@@ -1731,9 +1731,9 @@
       }
     },
     "node_modules/@matrixai/contexts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@matrixai/contexts/-/contexts-1.1.0.tgz",
-      "integrity": "sha512-sB4UrT8T6OICBujNxTOss8O+dAHnbfndBqZG0fO1PSZUgaZlXDg3cSz9ButbV4JLEz25UvPgh4ChvwTP31DUcQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/contexts/-/contexts-1.2.0.tgz",
+      "integrity": "sha512-MR/B02Kf4UoliP9b/gMMKsvWV6QM4JSPKTIqrhQP2tbOl3FwLI+AIhL3vgYEj1Xw+PP8bY5cr8ontJ8x6AJyMg==",
       "dependencies": {
         "@matrixai/async-cancellable": "^1.1.1",
         "@matrixai/async-locks": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@matrixai/async-cancellable": "^1.1.1",
     "@matrixai/async-init": "^1.8.4",
     "@matrixai/async-locks": "^4.0.0",
-    "@matrixai/contexts": "^1.1.0",
+    "@matrixai/contexts": "^1.2.0",
     "@matrixai/errors": "^1.1.7",
     "@matrixai/logger": "^3.1.0",
     "@matrixai/resources": "^1.1.5",

--- a/src/QUICClient.ts
+++ b/src/QUICClient.ts
@@ -16,7 +16,7 @@ import { quiche } from './native';
 import * as utils from './utils';
 import * as errors from './errors';
 import * as events from './events';
-import { clientDefault } from './config';
+import { clientDefault, minIdleTimeout } from './config';
 import QUICSocket from './QUICSocket';
 import QUICConnection from './QUICConnection';
 import QUICConnectionId from './QUICConnectionId';
@@ -87,7 +87,7 @@ class QUICClient extends EventTarget {
     },
     ctx?: Partial<ContextTimedInput>,
   ): PromiseCancellable<QUICClient>;
-  @timedCancellable(true, Infinity, errors.ErrorQUICClientCreateTimeOut)
+  @timedCancellable(true, minIdleTimeout, errors.ErrorQUICClientCreateTimeOut)
   public static async createQUICClient(
     {
       host,

--- a/src/QUICConnection.ts
+++ b/src/QUICConnection.ts
@@ -26,7 +26,7 @@ import { Timer } from '@matrixai/timer';
 import { context, timedCancellable } from '@matrixai/contexts/dist/decorators';
 import { withF } from '@matrixai/resources';
 import { utils as contextsUtils } from '@matrixai/contexts';
-import { buildQuicheConfig } from './config';
+import { buildQuicheConfig, minIdleTimeout } from './config';
 import QUICStream from './QUICStream';
 import { quiche } from './native';
 import * as events from './events';
@@ -237,7 +237,11 @@ class QUICConnection extends EventTarget {
         },
     ctx?: Partial<ContextTimedInput>,
   ): PromiseCancellable<QUICConnection>;
-  @timedCancellable(true, Infinity, errors.ErrorQUICConnectionStartTimeOut)
+  @timedCancellable(
+    true,
+    minIdleTimeout,
+    errors.ErrorQUICConnectionStartTimeOut,
+  )
   public static async createQUICConnection(
     args:
       | {

--- a/src/QUICConnection.ts
+++ b/src/QUICConnection.ts
@@ -267,12 +267,6 @@ class QUICConnection extends EventTarget {
         },
     @context ctx: ContextTimed,
   ): Promise<QUICConnection> {
-    const timeoutTime = ctx.timer.getTimeout();
-    if (timeoutTime !== Infinity && timeoutTime >= args.config.maxIdleTimeout) {
-      throw new errors.ErrorQUICConnectionInvalidConfig(
-        'connection timeout timer must be strictly less than maxIdleTimeout',
-      );
-    }
     ctx.signal.throwIfAborted();
     const abortProm = promise<never>();
     const abortHandler = () => {

--- a/src/QUICServer.ts
+++ b/src/QUICServer.ts
@@ -53,6 +53,7 @@ class QUICServer extends EventTarget {
   protected codeToReason: StreamCodeToReason | undefined;
   protected verifyCallback: VerifyCallback | undefined;
   protected connectionMap: QUICConnectionMap;
+  protected connectionConnectTime: number;
   // Used to track address string for logging ONLY
   protected address: string;
 
@@ -109,6 +110,7 @@ class QUICServer extends EventTarget {
     reasonToCode,
     codeToReason,
     verifyCallback,
+    connectionConnectTime = 2000,
     logger,
   }: {
     crypto: {
@@ -124,6 +126,7 @@ class QUICServer extends EventTarget {
     reasonToCode?: StreamReasonToCode;
     codeToReason?: StreamCodeToReason;
     verifyCallback?: VerifyCallback;
+    connectionConnectTime?: number;
     logger?: Logger;
   }) {
     super();
@@ -151,6 +154,7 @@ class QUICServer extends EventTarget {
     this.reasonToCode = reasonToCode;
     this.codeToReason = codeToReason;
     this.verifyCallback = verifyCallback;
+    this.connectionConnectTime = connectionConnectTime;
   }
 
   @ready(new errors.ErrorQUICServerNotRunning())
@@ -355,23 +359,28 @@ class QUICServer extends EventTarget {
       `Accepting new connection from QUIC packet from ${remoteInfo.host}:${remoteInfo.port}`,
     );
     const clientConnRef = Buffer.from(header.scid).toString('hex').slice(32);
-    const connectionProm = QUICConnection.createQUICConnection({
-      type: 'server',
-      scid: newScid,
-      dcid: dcidOriginal,
-      socket: this.socket,
-      remoteInfo,
-      data,
-      config: this.config,
-      reasonToCode: this.reasonToCode,
-      codeToReason: this.codeToReason,
-      verifyCallback: this.verifyCallback,
-      logger: this.logger.getChild(
-        `${QUICConnection.name} ${scid.toString().slice(32)}-${clientConnRef}`,
-      ),
-    });
+    let connection: QUICConnection;
     try {
-      await connectionProm;
+      connection = await QUICConnection.createQUICConnection(
+        {
+          type: 'server',
+          scid: newScid,
+          dcid: dcidOriginal,
+          socket: this.socket,
+          remoteInfo,
+          data,
+          config: this.config,
+          reasonToCode: this.reasonToCode,
+          codeToReason: this.codeToReason,
+          verifyCallback: this.verifyCallback,
+          logger: this.logger.getChild(
+            `${QUICConnection.name} ${scid
+              .toString()
+              .slice(32)}-${clientConnRef}`,
+          ),
+        },
+        { timer: this.connectionConnectTime },
+      );
     } catch (e) {
       // Ignoring any errors here as a failure to connect
       this.dispatchEvent(
@@ -383,7 +392,6 @@ class QUICServer extends EventTarget {
       );
       return;
     }
-    const connection = await connectionProm;
     // Handling connection events
     connection.addEventListener(
       'connectionError',

--- a/src/QUICServer.ts
+++ b/src/QUICServer.ts
@@ -53,7 +53,7 @@ class QUICServer extends EventTarget {
   protected codeToReason: StreamCodeToReason | undefined;
   protected verifyCallback: VerifyCallback | undefined;
   protected connectionMap: QUICConnectionMap;
-  protected connectionConnectTime: number;
+  protected connectTimeoutTime: number;
   // Used to track address string for logging ONLY
   protected address: string;
 
@@ -110,7 +110,7 @@ class QUICServer extends EventTarget {
     reasonToCode,
     codeToReason,
     verifyCallback,
-    connectionConnectTime = 2000,
+    connectTimeoutTime = 15000,
     logger,
   }: {
     crypto: {
@@ -126,7 +126,7 @@ class QUICServer extends EventTarget {
     reasonToCode?: StreamReasonToCode;
     codeToReason?: StreamCodeToReason;
     verifyCallback?: VerifyCallback;
-    connectionConnectTime?: number;
+    connectTimeoutTime?: number;
     logger?: Logger;
   }) {
     super();
@@ -154,7 +154,7 @@ class QUICServer extends EventTarget {
     this.reasonToCode = reasonToCode;
     this.codeToReason = codeToReason;
     this.verifyCallback = verifyCallback;
-    this.connectionConnectTime = connectionConnectTime;
+    this.connectTimeoutTime = connectTimeoutTime;
   }
 
   @ready(new errors.ErrorQUICServerNotRunning())
@@ -379,7 +379,7 @@ class QUICServer extends EventTarget {
               .slice(32)}-${clientConnRef}`,
           ),
         },
-        { timer: this.connectionConnectTime },
+        { timer: this.connectTimeoutTime },
       );
     } catch (e) {
       // Ignoring any errors here as a failure to connect

--- a/src/QUICServer.ts
+++ b/src/QUICServer.ts
@@ -53,7 +53,7 @@ class QUICServer extends EventTarget {
   protected codeToReason: StreamCodeToReason | undefined;
   protected verifyCallback: VerifyCallback | undefined;
   protected connectionMap: QUICConnectionMap;
-  protected connectTimeoutTime: number;
+  protected minIdleTimeout: number | undefined;
   // Used to track address string for logging ONLY
   protected address: string;
 
@@ -110,7 +110,7 @@ class QUICServer extends EventTarget {
     reasonToCode,
     codeToReason,
     verifyCallback,
-    connectTimeoutTime = 15000,
+    minIdleTimeout,
     logger,
   }: {
     crypto: {
@@ -126,7 +126,7 @@ class QUICServer extends EventTarget {
     reasonToCode?: StreamReasonToCode;
     codeToReason?: StreamCodeToReason;
     verifyCallback?: VerifyCallback;
-    connectTimeoutTime?: number;
+    minIdleTimeout?: number;
     logger?: Logger;
   }) {
     super();
@@ -154,7 +154,7 @@ class QUICServer extends EventTarget {
     this.reasonToCode = reasonToCode;
     this.codeToReason = codeToReason;
     this.verifyCallback = verifyCallback;
-    this.connectTimeoutTime = connectTimeoutTime;
+    this.minIdleTimeout = minIdleTimeout;
   }
 
   @ready(new errors.ErrorQUICServerNotRunning())
@@ -379,7 +379,7 @@ class QUICServer extends EventTarget {
               .slice(32)}-${clientConnRef}`,
           ),
         },
-        { timer: this.connectTimeoutTime },
+        { timer: this.minIdleTimeout },
       );
     } catch (e) {
       // Ignoring any errors here as a failure to connect

--- a/src/QUICSocket.ts
+++ b/src/QUICSocket.ts
@@ -8,6 +8,8 @@ import { running } from '@matrixai/async-init';
 import { StartStop, ready } from '@matrixai/async-init/dist/StartStop';
 import { RWLockWriter } from '@matrixai/async-locks';
 import { status } from '@matrixai/async-init/dist/utils';
+import { withF } from '@matrixai/resources';
+import { utils as contextsUtils } from '@matrixai/contexts';
 import QUICConnectionId from './QUICConnectionId';
 import QUICConnectionMap from './QUICConnectionMap';
 import { quiche } from './native';
@@ -108,11 +110,9 @@ class QUICSocket extends EventTarget {
     // Acquire the conn lock, this ensures mutual exclusion
     // for state changes on the internal connection
     try {
-      await utils.withMonitor(
-        undefined,
-        connection.lockbox,
-        RWLockWriter,
-        async (mon) => {
+      await withF(
+        [contextsUtils.monitor(connection.lockbox, RWLockWriter)],
+        async ([mon]) => {
           await mon.withF(connection.lockCode, async (mon) => {
             // Even if we are `stopping`, the `quiche` library says we need to
             // continue processing any packets.

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,12 +23,26 @@ const sigalgs = [
   'ed25519',
 ].join(':');
 
+/**
+ * Usually we would create separate timeouts for connecting vs idling.
+ * Unfortunately quiche only has 1 config option that controls both.
+ * And it is not possible to mutate this option after connecting.
+ * Therefore, this option is just a way to set a shorter connecting timeout
+ * compared to the idling timeout.
+ * If this is the larger than the `maxIdleTimeout` (remember that `0` is `Infinity`) for `maxIdleTimeout`, then this has no effect.
+ * This only has an effect if this is set to a number less than `maxIdleTimeout`.
+ * Thus, it is the "minimum boundary" of the timeout during connecting.
+ * While the `maxIdleTimeout` is still the "maximum boundary" during connecting.
+ */
+const minIdleTimeout = Infinity;
+
 const clientDefault: QUICConfig = {
   sigalgs,
   verifyPeer: true,
   verifyAllowFail: false,
   grease: true,
-  maxIdleTimeout: 1 * 60 * 1000,
+  keepAliveIntervalTime: undefined,
+  maxIdleTimeout: 0,
   maxRecvUdpPayloadSize: quiche.MAX_DATAGRAM_SIZE, // 65527
   maxSendUdpPayloadSize: quiche.MIN_CLIENT_INITIAL_LEN, // 1200,
   initialMaxData: 10 * 1024 * 1024,
@@ -48,7 +62,8 @@ const serverDefault: QUICConfig = {
   verifyPeer: false,
   verifyAllowFail: false,
   grease: true,
-  maxIdleTimeout: 1 * 60 * 1000,
+  keepAliveIntervalTime: undefined,
+  maxIdleTimeout: 0,
   maxRecvUdpPayloadSize: quiche.MAX_DATAGRAM_SIZE, // 65527
   maxSendUdpPayloadSize: quiche.MIN_CLIENT_INITIAL_LEN, // 1200
   initialMaxData: 10 * 1024 * 1024,
@@ -188,4 +203,4 @@ function buildQuicheConfig(config: QUICConfig): QuicheConfig {
   return quicheConfig;
 }
 
-export { clientDefault, serverDefault, buildQuicheConfig };
+export { minIdleTimeout, clientDefault, serverDefault, buildQuicheConfig };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,12 +8,8 @@ import type {
   ServerCrypto,
 } from './types';
 import type { Connection } from './native';
-import type { LockBox, RWLockWriter } from '@matrixai/async-locks';
-import type { Monitor } from '@matrixai/async-locks';
 import dns from 'dns';
 import { IPv4, IPv6, Validator } from 'ip-num';
-import { withF } from '@matrixai/resources';
-import { utils as contextsUtils } from '@matrixai/contexts';
 import QUICConnectionId from './QUICConnectionId';
 import * as errors from './errors';
 
@@ -466,28 +462,6 @@ function streamStats(
 `;
 }
 
-/**
- * Used as a clean way to create a new monitor if it doesn't exist, otherwise uses the existing one.
- */
-async function withMonitor<T>(
-  mon: Monitor<RWLockWriter> | undefined,
-  lockBox: LockBox<RWLockWriter>,
-  lockConstructor: { new (): RWLockWriter },
-  fun: (mon: Monitor<RWLockWriter>) => Promise<T>,
-  locksPending?: Map<string, { count: number }>,
-): Promise<T> {
-  if (mon == null) {
-    return await withF(
-      [contextsUtils.monitor(lockBox, lockConstructor, locksPending)],
-      async ([mon]) => {
-        return await fun(mon);
-      },
-    );
-  } else {
-    return await fun(mon);
-  }
-}
-
 export {
   isIPv4,
   isIPv6,
@@ -519,5 +493,4 @@ export {
   validateToken,
   sleep,
   streamStats,
-  withMonitor,
 };

--- a/tests/QUICClient.test.ts
+++ b/tests/QUICClient.test.ts
@@ -280,62 +280,6 @@ describe(QUICClient.name, () => {
         ),
       ).rejects.toThrow(errors.ErrorQUICClientCreateTimeOut);
     });
-    test('ctx timer must be less than maxIdleTimeout', async () => {
-      // Larger timer throws
-      await expect(
-        QUICClient.createQUICClient(
-          {
-            host: localhost,
-            port: 56666,
-            localHost: localhost,
-            crypto: {
-              ops: clientCrypto,
-            },
-            logger: logger.getChild(QUICClient.name),
-            config: {
-              maxIdleTimeout: 200,
-              verifyPeer: false,
-            },
-          },
-          { timer: 1000 },
-        ),
-      ).rejects.toThrow(errors.ErrorQUICConnectionInvalidConfig);
-      // Smaller keepAliveIntervalTime doesn't cause a problem
-      await expect(
-        QUICClient.createQUICClient(
-          {
-            host: localhost,
-            port: 56666,
-            localHost: localhost,
-            crypto: {
-              ops: clientCrypto,
-            },
-            logger: logger.getChild(QUICClient.name),
-            config: {
-              maxIdleTimeout: 200,
-              verifyPeer: false,
-            },
-          },
-          { timer: 100 },
-        ),
-      ).rejects.not.toThrow(errors.ErrorQUICConnectionInvalidConfig);
-      // Not setting an interval doesn't cause a problem either
-      await expect(
-        QUICClient.createQUICClient({
-          host: localhost,
-          port: 56666,
-          localHost: localhost,
-          crypto: {
-            ops: clientCrypto,
-          },
-          logger: logger.getChild(QUICClient.name),
-          config: {
-            maxIdleTimeout: 200,
-            verifyPeer: false,
-          },
-        }),
-      ).rejects.not.toThrow(errors.ErrorQUICConnectionInvalidConfig);
-    });
     test('client times out with ctx signal while starting', async () => {
       // QUICClient repeatedly dials until the connection timeout
       const abortController = new AbortController();


### PR DESCRIPTION
### Description

This PR addresses some small issues in the `js-quic` code.

As per discussion, the constraint on the connection start timeout should be removed. During usage we can set this to whatever without the context of the idle timeout being know. In that case it's very likely to throw an error.  We'll allow any value to be valid with the caveat that a lower idle timeout will supersede the startup timeout.

During review we found that server type connections startup timeout defaults to infinity. creation here depends on establishment and secure events so it's possible for a server connection to be stuck in limbo if these events are never reached. A default start timeout should be applied here. 

### Issues Fixed

* Fixes #48 

### Tasks

- [x] 1. Address issue #48 
- [ ] 2. Apply startup timeout to a server connection getting created
- [ ] 3. Remove constraint between start timeout and max idle timeout values. A longer startup timeout will be allowed but superseded by the idle timeout.

### Final checklist

* [ ] Domain specific tests
* [ ] Full tests
* [ ] Updated inline-comment documentation
* [ ] Lint fixed
* [ ] Squash and rebased
* [ ] Sanity check the final build
