### PR TITLE
feat: expose more `connectionId` information

### DIFF
--- a/src/QUICClient.ts
+++ b/src/QUICClient.ts
@@ -315,19 +315,8 @@ class QUICClient {
    */
   protected handleEventQUICClientError = (evt: events.EventQUICClientError) => {
     const error = evt.detail;
-    if (
-      (error instanceof errors.ErrorQUICConnectionLocal ||
-        error instanceof errors.ErrorQUICConnectionPeer) &&
-      ((!error.data.isApp &&
-        error.data.errorCode === ConnectionErrorCode.NoError) ||
-        (error.data.isApp && error.data.errorCode === 0))
-    ) {
-      // Log out the excpetion as an info when it is graceful
-      this.logger.info(utils.formatError(error));
-    } else {
-      // Log out the exception as an error when it is not graceful
-      this.logger.error(utils.formatError(error));
-    }
+    // Log out the error
+    this.logger.info(utils.formatError(error));
     if (
       error instanceof errors.ErrorQUICClientInternal ||
       error instanceof errors.ErrorQUICConnectionInternal

--- a/src/QUICConnection.ts
+++ b/src/QUICConnection.ts
@@ -400,7 +400,13 @@ class QUICConnection {
    * This is the source connection ID.
    */
   public get connectionId() {
-    return new QUICConnectionId(this.conn.sourceId());
+    const sourceId = this.conn.sourceId();
+    // Zero copy construction of QUICConnectionId
+    return new QUICConnectionId(
+      sourceId.buffer,
+      sourceId.byteOffset,
+      sourceId.byteLength,
+    );
   }
 
   /**
@@ -409,7 +415,13 @@ class QUICConnection {
    */
   @ready(new errors.ErrorQUICConnectionNotRunning())
   public get connectionIdPeer() {
-    return new QUICConnectionId(this.conn.destinationId());
+    const destinationId = this.conn.destinationId();
+    // Zero copy construction of QUICConnectionId
+    return new QUICConnectionId(
+      destinationId.buffer,
+      destinationId.byteOffset,
+      destinationId.byteLength,
+    );
   }
 
   /**

--- a/src/QUICConnection.ts
+++ b/src/QUICConnection.ts
@@ -181,19 +181,8 @@ class QUICConnection {
   ) => {
     const error = evt.detail;
     this.errorLast = error;
-    if (
-      (error instanceof errors.ErrorQUICConnectionLocal ||
-        error instanceof errors.ErrorQUICConnectionPeer) &&
-      ((!error.data.isApp &&
-        error.data.errorCode === ConnectionErrorCode.NoError) ||
-        (error.data.isApp && error.data.errorCode === 0))
-    ) {
-      // Log out the excpetion as an info when it is graceful
-      this.logger.info(utils.formatError(error));
-    } else {
-      // Log out the exception as an error when it is not graceful
-      this.logger.error(utils.formatError(error));
-    }
+    // Log out error for debugging
+    this.logger.info(utils.formatError(error));
     if (error instanceof errors.ErrorQUICConnectionInternal) {
       throw error;
     }

--- a/src/QUICServer.ts
+++ b/src/QUICServer.ts
@@ -72,7 +72,8 @@ class QUICServer {
    */
   protected handleEventQUICServerError = (evt: events.EventQUICServerError) => {
     const error = evt.detail;
-    this.logger.error(utils.formatError(error));
+    // Log out error for debugging
+    this.logger.info(utils.formatError(error));
     if (error instanceof errors.ErrorQUICServerInternal) {
       throw error;
     }

--- a/src/QUICSocket.ts
+++ b/src/QUICSocket.ts
@@ -56,7 +56,8 @@ class QUICSocket {
 
   protected handleEventQUICSocketError = (evt: events.EventQUICSocketError) => {
     const error = evt.detail;
-    this.logger.error(utils.formatError(error));
+    // Log out error for debugging
+    this.logger.debug(utils.formatError(error));
   };
 
   protected handleEventQUICSocketClose = async () => {

--- a/src/QUICStream.ts
+++ b/src/QUICStream.ts
@@ -150,7 +150,8 @@ class QUICStream implements ReadableWritablePair<Uint8Array, Uint8Array> {
   protected handleEventQUICStreamError = (evt: events.EventQUICStreamError) => {
     const error = evt.detail;
     if (error instanceof errors.ErrorQUICStreamInternal) {
-      this.logger.error(utils.formatError(error));
+      // Log out error for debugging
+      this.logger.debug(utils.formatError(error));
       throw error;
     }
     if (

--- a/tests/QUICClient.test.ts
+++ b/tests/QUICClient.test.ts
@@ -15,7 +15,7 @@ import * as testsUtils from './utils';
 import { generateTLSConfig, sleep } from './utils';
 
 describe(QUICClient.name, () => {
-  const logger = new Logger(`${QUICClient.name} Test`, LogLevel.SILENT, [
+  const logger = new Logger(`${QUICClient.name} Test`, LogLevel.WARN, [
     new StreamHandler(
       formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
     ),

--- a/tests/QUICServer.test.ts
+++ b/tests/QUICServer.test.ts
@@ -10,7 +10,7 @@ import * as errors from '@/errors';
 import * as testsUtils from './utils';
 
 describe(QUICServer.name, () => {
-  const logger = new Logger(`${QUICServer.name} Test`, LogLevel.SILENT, [
+  const logger = new Logger(`${QUICServer.name} Test`, LogLevel.WARN, [
     new StreamHandler(
       formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
     ),

--- a/tests/QUICSocket.test.ts
+++ b/tests/QUICSocket.test.ts
@@ -13,7 +13,7 @@ import * as events from '@/events';
 import * as testsUtils from './utils';
 
 describe(QUICSocket.name, () => {
-  const logger = new Logger(`${QUICSocket.name} Test`, LogLevel.SILENT, [
+  const logger = new Logger(`${QUICSocket.name} Test`, LogLevel.WARN, [
     new StreamHandler(),
   ]);
   // This has to be setup asynchronously due to key generation
@@ -296,7 +296,7 @@ describe(QUICSocket.name, () => {
     test('error and close event lifecycle', async () => {
       // We expect error logs
       const socketLogger = logger.getChild('abc');
-      socketLogger.setLevel(LogLevel.SILENT);
+      socketLogger.setLevel(LogLevel.WARN);
       const socket = new QUICSocket({
         logger: socketLogger,
       });
@@ -865,7 +865,7 @@ describe(QUICSocket.name, () => {
         };
         // We expect lots of error logs
         const socketLogger = logger.getChild('abc');
-        socketLogger.setLevel(LogLevel.SILENT);
+        socketLogger.setLevel(LogLevel.WARN);
         const socket = new QUICSocket({
           logger: socketLogger,
         });

--- a/tests/QUICStream.test.ts
+++ b/tests/QUICStream.test.ts
@@ -10,7 +10,7 @@ import * as testsUtils from './utils';
 import { generateTLSConfig } from './utils';
 
 describe(QUICStream.name, () => {
-  const logger = new Logger(`${QUICStream.name} Test`, LogLevel.SILENT, [
+  const logger = new Logger(`${QUICStream.name} Test`, LogLevel.WARN, [
     new StreamHandler(
       formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
     ),

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -12,7 +12,7 @@ import { generateTLSConfig, handleStreamProm, sleep } from './utils';
 import * as testsUtils from './utils';
 
 describe('Concurrency tests', () => {
-  const logger = new Logger(`${QUICClient.name} Test`, LogLevel.SILENT, [
+  const logger = new Logger(`${QUICClient.name} Test`, LogLevel.WARN, [
     new StreamHandler(
       formatting.format`${formatting.level}:${formatting.keys}:${formatting.msg}`,
     ),


### PR DESCRIPTION
### Description

I need to expose more `connectionId` information so I compare connections better. This exposes the destination id as `connectionIdPeer` of the connection as well as a derived `connectionIdShared`.

Changes:
* Exposed connection destination ID
* Created a common ID that is identical for both sides of the connection. Derived from the source and destination ID.
* The `quiche` connection is now the Source Of Truth for these IDs. The destinationId is only know after establishing and is only valid while running.
* Added test demonstrating the new Ids and how they relate to each other.

As for logging, I'm switching non-internal connection and stream error logs to debug level. closing stream or connection with a non-0 code is not exceptional. Internal errors are.


### Issues Fixed

* No issues directly addressed.
* Related: https://github.com/MatrixAI/Polykey/pull/609

### Tasks
1. [x] expose more `connectionId` information on the `QUICConnection`.
2. [x] Reduce `ERROR` and `WARN` level logs for failing connections and streams. Application can make a decision to log these as errors or not. 

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
