### PR TITLE
fix ending `QUICConnection` with `force: false`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1471,6 +1471,54 @@
       "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.0.tgz",
       "integrity": "sha512-C4JWpgbNik3V99bfGfDell5cH3JULD67eEq9CeXl4rYgsvanF8hhuY84ZYvndPhimt9qjA9/Z8uExKGoiv1zVw=="
     },
+    "node_modules/@matrixai/quic-darwin-arm64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.0.tgz",
+      "integrity": "sha512-PlMjRHCXoIdN2X3uh0GRPj8WD32tFgvnlGJFl5kng2R8SjLWNiT3afFLW6G0Gwb7Net4iVBUvU6b2S5B9AgaxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-darwin-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.0.tgz",
+      "integrity": "sha512-jjVaQv3j5EiXO0ORWICv2VHY59KiwmptCHXkA8VDsbqYXRS8DrafCAzhOEt5WCk6u7cjz6m9uiqMqFSqEFDVqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-linux-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.0.tgz",
+      "integrity": "sha512-MCPjuCLC9oCNRnNr+S6QWY26SjFREPeRMWXwg+1v34dT6Xu0WVdcLfOqFPBalEPGyb4NWbMkRz7ZZDLHpQ1FXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@matrixai/quic-win32-x64": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.0.tgz",
+      "integrity": "sha512-nvlctqR6ETC+KG7oJ3TxnI3i1zMFhkrIaw8453B43ljfIiHI46BsKJNuRrXqzx0FwulzJQor5C3BrzpGqtY8Ag==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@matrixai/resources": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@matrixai/resources/-/resources-1.1.5.tgz",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,13 @@ const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder('utf-8');
 
 /**
+ * Used to yield to the event loop to allow other micro tasks to process
+ */
+async function yieldMicro(): Promise<void> {
+  return await new Promise<void>((r) => queueMicrotask(r));
+}
+
+/**
  * Convert callback-style to promise-style
  * If this is applied to overloaded function
  * it will only choose one of the function signatures to use
@@ -550,6 +557,7 @@ function isStreamReset(e: Error): number | false {
 export {
   textEncoder,
   textDecoder,
+  yieldMicro,
   promisify,
   promise,
   bufferWrap,

--- a/tests/QUICClient.test.ts
+++ b/tests/QUICClient.test.ts
@@ -1775,6 +1775,7 @@ describe(QUICClient.name, () => {
 
     // Handling client error event
     const clientErrorProm = promise<never>();
+    void clientErrorProm.p.catch(() => {}); // Ignore unhandled rejection
     client.addEventListener(
       events.EventQUICClientError.name,
       (evt: events.EventQUICClientError) => clientErrorProm.rejectP(evt.detail),
@@ -1783,6 +1784,7 @@ describe(QUICClient.name, () => {
 
     // Handling client destroy event
     const clientDestroyedProm = promise<void>();
+    void clientDestroyedProm.p.catch(() => {}); // Ignore unhandled rejection
     client.addEventListener(
       events.EventQUICClientDestroyed.name,
       () => clientDestroyedProm.resolveP(),

--- a/tests/QUICStream.test.ts
+++ b/tests/QUICStream.test.ts
@@ -1313,6 +1313,8 @@ describe(QUICStream.name, () => {
         })(),
       );
     }
+    // Yield to allow streams to propagate
+    await sleep(0);
 
     // Start unforced close of client
     const clientDestroyP = client.destroy({ force: false });
@@ -1402,6 +1404,8 @@ describe(QUICStream.name, () => {
         })(),
       );
     }
+    // Yield to allow streams to propagate
+    await sleep(0);
 
     // Start unforced close of server
     const serverStopP = server.stop({ force: false });
@@ -1489,7 +1493,87 @@ describe(QUICStream.name, () => {
     await expect(asd).rejects.toThrow('read 1');
 
     waitResolveP();
+    await Promise.all(activeServerStreams);
     await clientDestroyP;
     await server.stop({ force: true });
+  });
+  test('connection can be forced closed after unforced destroy', async () => {
+    const message = Buffer.from('The Quick Brown Fox Jumped Over The Lazy Dog');
+    const connectionEventProm =
+      utils.promise<events.EventQUICServerConnection>();
+    const tlsConfig = await generateTLSConfig(defaultType);
+    const server = new QUICServer({
+      crypto: {
+        key,
+        ops: serverCrypto,
+      },
+      logger: logger.getChild(QUICServer.name),
+      config: {
+        key: tlsConfig.leafKeyPairPEM.privateKey,
+        cert: tlsConfig.leafCertPEM,
+        verifyPeer: false,
+      },
+    });
+    socketCleanMethods.extractSocket(server);
+    server.addEventListener(
+      events.EventQUICServerConnection.name,
+      (e: events.EventQUICServerConnection) => connectionEventProm.resolveP(e),
+    );
+    await server.start({
+      host: localhost,
+    });
+    const client = await QUICClient.createQUICClient({
+      host: localhost,
+      port: server.port,
+      localHost: localhost,
+      crypto: {
+        ops: clientCrypto,
+      },
+      logger: logger.getChild(QUICClient.name),
+      config: {
+        verifyPeer: false,
+      },
+    });
+    socketCleanMethods.extractSocket(client);
+    const conn = (await connectionEventProm.p).detail;
+
+    // Do the test
+    const { p: waitP, resolveP: waitResolveP } = utils.promise();
+    const activeServerStreams: Array<Promise<void>> = [];
+    conn.addEventListener(
+      events.EventQUICConnectionStream.name,
+      async (streamEvent: events.EventQUICConnectionStream) => {
+        const stream = streamEvent.detail;
+        await waitP;
+        const streamProm = stream.readable
+          .pipeTo(stream.writable)
+          .catch(() => {});
+        activeServerStreams.push(streamProm);
+      },
+    );
+
+    const stream = client.connection.newStream();
+    const writer = stream.writable.getWriter();
+    await writer.write(message);
+    await writer.close();
+
+    // Start unforced close of client
+    const clientDestroyP = client.destroy({ force: false });
+
+    const result = await Promise.race([
+      clientDestroyP.then(() => true),
+      sleep(500).then(() => false),
+    ]);
+
+    expect(result).toBe(false);
+
+    // We can force close the streams causing client destruction to end
+    client.connection.destroyStreams();
+    await clientDestroyP;
+    await Promise.allSettled(activeServerStreams);
+
+    await server.stop({ force: true });
+    waitResolveP();
+    await waitP;
   });
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -23,10 +23,6 @@ async function sleep(ms: number): Promise<void> {
   return await new Promise<void>((r) => setTimeout(r, ms));
 }
 
-async function yieldMicro(): Promise<void> {
-  return await new Promise<void>((r) => queueMicrotask(r));
-}
-
 async function randomBytes(data: ArrayBuffer) {
   webcrypto.getRandomValues(new Uint8Array(data));
 }
@@ -853,7 +849,6 @@ function createReasonConverters() {
 
 export {
   sleep,
-  yieldMicro,
   randomBytes,
   generateKeyPairRSA,
   generateKeyPairECDSA,


### PR DESCRIPTION
### Description

While working on https://github.com/MatrixAI/Polykey/pull/609 I found the following problems.

1. When ending a connection with `force: false` any currently running streams will end with an error. The expected behaviour is that they finish gracefully.
2. If we end a connection with `force: false` we have no way to force the end after the fact. So if we wanted to gracefully end something at first but then need to force it to end afterwards, we have no way of doing this.

On top of fixes we need to expand the features of a connection slightly here.
1. Allow the ability to force close all streams at any time to allow skipping the graceful end of streams when ending the connection with `force: false`
2. when ending a connection with `force: false` we don't want any new connections to be started. Any new connections from either direction should be rejected.

### Issues Fixed

* No issues are directly fixed by this PR.
* Related: https://github.com/MatrixAI/Polykey/pull/609

### Tasks

- [x] 1. When a connection is closed with `force: false` it *should* wait for all streams to gracefully end. Right now they throw an error.
- [x] 2. When a connection is ending, forced or otherwise, all new streams should be rejected. when `force: false` we should allow all active streams to end gracefully but no new ones should be created from either direction.
- [x] 3. When ending a connection with `force: false` we want the ability to force the end at any time. So we need a method of force closing all active streams at any time.

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
