### PR TITLE
fix: added `readableChunkSize` parameter to config and defaulted the …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,6 +1468,54 @@
       "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.2.tgz",
       "integrity": "sha512-nNliLCnbg6hGS2+gGtQfeeyVNJzOmvqz90AbrQsHPNiE08l3YsENL2JQt9d454SorD1Ud51ymZdDCkeMLWY93A=="
     },
+    "node_modules/@matrixai/quic-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-/Dho39T4sjbdOeC01F4rDesssQ9nvfdH57Ap95870LoY1KwXWh+c7cAtdv9FVma2R+9cqdKNkfsMFcS68Y15KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-soxYopXZjoHxSMvpoNEKQQS1uQcXK2aIuaJHDgZINz4UbeLW0NsoEqMgUJKXeWZNR+aaVxhL5fE5+5Ypwej80Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-linux-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.1.4.tgz",
+      "integrity": "sha512-LRKkVX++UZEj00XhfD0cPe4uFQJeHOBpQl+v6BIL7LSB9KxsmQRgbDh5mvxvWAwnh5EI51aSgn4auWEdHMDjTw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@matrixai/quic-win32-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.1.4.tgz",
+      "integrity": "sha512-JNIQn1GRCRDm23v7hkqNVRm0oV928AHVfNPXJOB6FqBtbmbe/DaqUnppFi3qqUxm5Agguhd1rgNfKkL4HRhq8A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@matrixai/resources": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@matrixai/resources/-/resources-1.1.5.tgz",

--- a/src/QUICStream.ts
+++ b/src/QUICStream.ts
@@ -239,21 +239,11 @@ class QUICStream implements ReadableWritablePair<Uint8Array, Uint8Array> {
     // This will setup the readable chunk buffer with the size set to the
     // configured per-stream buffer size. Note that this doubles the memory
     // usage of each stream due to maintaining both the Rust and JS buffers
-    if (this.type === 'uni') {
-      if (initiated === 'local') {
-        // We expect the readable stream to be closed
-        this.readableChunk = undefined;
-      } else if (initiated === 'peer') {
-        this.readableChunk = Buffer.allocUnsafe(config.initialMaxStreamDataUni);
-      }
-    } else if (this.type === 'bidi' && initiated === 'local') {
-      this.readableChunk = Buffer.allocUnsafe(
-        config.initialMaxStreamDataBidiLocal,
-      );
-    } else if (this.type === 'bidi' && initiated === 'peer') {
-      this.readableChunk = Buffer.allocUnsafe(
-        config.initialMaxStreamDataBidiRemote,
-      );
+    if (this.type === 'uni' && initiated === 'local') {
+      // We expect the readable stream to be closed
+      this.readableChunk = undefined;
+    } else {
+      this.readableChunk = Buffer.allocUnsafe(config.readableChunkSize);
     }
     if (this.type === 'uni' && initiated === 'local') {
       // This is just a dummy stream that will be auto-closed during creation

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ const clientDefault: QUICConfig = {
   disableActiveMigration: true,
   applicationProtos: ['quic'],
   enableEarlyData: true,
+  readableChunkSize: 4 * 1024,
 };
 
 const serverDefault: QUICConfig = {
@@ -83,6 +84,7 @@ const serverDefault: QUICConfig = {
   disableActiveMigration: true,
   applicationProtos: ['quic'],
   enableEarlyData: true,
+  readableChunkSize: 4 * 1024,
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,7 +177,7 @@ type QUICConfig = {
   logKeys?: string;
 
   /**
-   * Enable "Generate Random extensions and Sustain Extensibilty".
+   * Enable "Generate Random extensions and Sustain Extensibility".
    * This prevents protocol ossification by periodically introducing
    * random no-op values in the optional fields in TLS.
    * This defaults to true.
@@ -305,6 +305,12 @@ type QUICConfig = {
   applicationProtos: string[];
 
   enableEarlyData: boolean;
+
+  /**
+   * Defines the size of the Buffer used to read out data from the readable stream.
+   * This affects amount of memory reserved by the stream.
+   */
+  readableChunkSize: number;
 };
 
 type QUICClientConfigInput = Partial<QUICConfig>;


### PR DESCRIPTION
### Description

This PR addresses the excessive memory used by each QUICStream by providing a `readableChunkSize` config parameter and using that as the size when allocating the `Buffer`. This is defaulted to 4KB which is much less than the 1MB that was used before.

### Issues Fixed

* Fixes #83 

### Tasks
- [X] 1. Add config option for setting the amount of memory used for the readable buffer.
- [X] 2. reduce the amount reserved memory to the kilobyte range for each QUICStream.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
