### PR TITLE
fix: using `reasonToCode` instead of using hard coded shutdown codes …

### DIFF
--- a/src/QUICConnection.ts
+++ b/src/QUICConnection.ts
@@ -542,10 +542,18 @@ class QUICConnection {
         // No `QUICStream` objects could have been created, however quiche stream
         // state should be cleaned up, and this can be done synchronously
         for (const streamId of this.conn.readable() as Iterable<StreamId>) {
-          this.conn.streamShutdown(streamId, quiche.Shutdown.Read, 0);
+          this.conn.streamShutdown(
+            streamId,
+            quiche.Shutdown.Read,
+            this.reasonToCode('read', e),
+          );
         }
         for (const streamId of this.conn.writable() as Iterable<StreamId>) {
-          this.conn.streamShutdown(streamId, quiche.Shutdown.Write, 0);
+          this.conn.streamShutdown(
+            streamId,
+            quiche.Shutdown.Write,
+            this.reasonToCode('write', e),
+          );
         }
         // According to RFC9000, closing while in the middle of a handshake
         // should use a transport error code `APPLICATION_ERROR`.
@@ -954,8 +962,16 @@ class QUICConnection {
       if (quicStream == null) {
         if (this[running] === false || this[status] === 'stopping') {
           // We should reject new connections when stopping
-          this.conn.streamShutdown(streamId, Shutdown.Write, 1);
-          this.conn.streamShutdown(streamId, Shutdown.Read, 1);
+          this.conn.streamShutdown(
+            streamId,
+            Shutdown.Write,
+            this.reasonToCode('write', errors.ErrorQUICConnectionStopping),
+          );
+          this.conn.streamShutdown(
+            streamId,
+            Shutdown.Read,
+            this.reasonToCode('read', errors.ErrorQUICConnectionStopping),
+          );
           continue;
         }
 
@@ -990,8 +1006,16 @@ class QUICConnection {
       if (quicStream == null) {
         if (this[running] === false || this[status] === 'stopping') {
           // We should reject new connections when stopping
-          this.conn.streamShutdown(streamId, Shutdown.Write, 1);
-          this.conn.streamShutdown(streamId, Shutdown.Read, 1);
+          this.conn.streamShutdown(
+            streamId,
+            Shutdown.Write,
+            this.reasonToCode('write', errors.ErrorQUICConnectionStopping),
+          );
+          this.conn.streamShutdown(
+            streamId,
+            Shutdown.Read,
+            this.reasonToCode('read', errors.ErrorQUICConnectionStopping),
+          );
           continue;
         }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -92,6 +92,10 @@ class ErrorQUICConnection<T> extends ErrorQUIC<T> {
   static description = 'QUIC Connection error';
 }
 
+class ErrorQUICConnectionStopping<T> extends ErrorQUICConnection<T> {
+  static description = 'QUIC Connection is stopping';
+}
+
 class ErrorQUICConnectionNotRunning<T> extends ErrorQUICConnection<T> {
   static description = 'QUIC Connection is not running';
 }
@@ -297,6 +301,7 @@ export {
   ErrorQUICServerNewConnection,
   ErrorQUICServerInternal,
   ErrorQUICConnection,
+  ErrorQUICConnectionStopping,
   ErrorQUICConnectionNotRunning,
   ErrorQUICConnectionClosed,
   ErrorQUICConnectionStartData,

--- a/tests/QUICStream.test.ts
+++ b/tests/QUICStream.test.ts
@@ -1487,12 +1487,12 @@ describe(QUICStream.name, () => {
     // Creating a stream on the server side should throw
     const newStream = conn.newStream();
     await newStream.writable.close();
-    const asd = (async () => {
+    const code = (async () => {
       for await (const _ of newStream.readable) {
         // Do nothing
       }
     })();
-    await expect(asd).rejects.toThrow('read 1');
+    await expect(code).rejects.toThrow('read 0');
 
     waitResolveP();
     await Promise.all(activeServerStreams);


### PR DESCRIPTION
### Description

This removes the use of hard-coded error codes for shutting down quiche streams by using codes provided by `reasonToCode`

### Issues Fixed

* Fixes #77 

### Tasks
- [X] 1. remove hard-coded codes used with `streamShutdown` and use codes provided by `reasonToCode`.


### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
