### PR TITLE
feat: adding `x64+arm64` universal binary for `darwin`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -220,12 +220,16 @@ build:macos:
     - hash -r
     - npm install --ignore-scripts
     - export PATH="$(npm root)/.bin:$PATH"
+    - export PATH="$(npm root)/.bin:$PATH"
     # Gitlab MacOS already has rust installed
     # This will override the system installed rust
     - export PATH="$HOME/.cargo/bin:$PATH"
     # Build x64 and arm64 separately
     - npm run prebuild --verbose -- --arch x64 --production
     - npm run prebuild --verbose -- --arch arm64 --production
+    - lipo -create -output prebuild/quic-darwin-x64+arm64.node prebuild/quic-darwin-arm64.node prebuild/quic-darwin-x64.node
+    # Force remove any downloaded native bindings, so we only test with our builds
+    - rm -rf node_modules/@matrixai/quic-*
     - npm test -- --ci --coverage
     - npm run bench
   artifacts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,6 +1468,54 @@
       "resolved": "https://registry.npmjs.org/@matrixai/logger/-/logger-3.1.2.tgz",
       "integrity": "sha512-nNliLCnbg6hGS2+gGtQfeeyVNJzOmvqz90AbrQsHPNiE08l3YsENL2JQt9d454SorD1Ud51ymZdDCkeMLWY93A=="
     },
+    "node_modules/@matrixai/quic-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-arm64/-/quic-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-TutHRdQoPYPvwg8Fs6t+JmedKWn/7mJG63c5ZFyw9D58a90OzYr47re2qknKNjH/dgBIyybhBYTAltkOcXxzOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-darwin-x64/-/quic-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-HMIhCHjAvvAgSap2gQyKYgWyhikDtmU9KbqtReMT3tP8KG3jNPAw2YuF7vucVR9k6FaMufISLYyBvWQSadTxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@matrixai/quic-linux-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-linux-x64/-/quic-linux-x64-1.2.1.tgz",
+      "integrity": "sha512-WgvzATQhuVMV1cCiV0rRS9Tn3BL6LZ37OWBeQY20OJB4yaF9FR3xgUdATY3AVgF1FAdwvCHUJCF5BgzQmq8NMw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@matrixai/quic-win32-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@matrixai/quic-win32-x64/-/quic-win32-x64-1.2.1.tgz",
+      "integrity": "sha512-2F/llbBRzd2ohLLBZSW2ZIQTq8EHZ6jsrkv+/x0gggvRKaoPKmE2UMqcAYrfX/h5D48Gb3/JynD6AtFYGSBKFw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@matrixai/resources": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@matrixai/resources/-/resources-1.1.5.tgz",


### PR DESCRIPTION
### Description

This PR adds a universal `quic-darwin-x64+arm64.node` binary to the prebuilds.

### Issues Fixed

* Related: https://github.com/MatrixAI/Polykey-CLI/issues/152

### Tasks
- [x] 1. Update `builds:macos` job to create an universal `x64+arm64` binary.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
