### PR TITLE
fix: we now abort starting connection when stopping the `QUICServer`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -93,6 +93,10 @@ class ErrorQUICServerInternal<T> extends ErrorQUICServer<T> {
   static description = 'QUIC Server internal error';
 }
 
+class ErrorQUICServerStopping<T> extends ErrorQUICServer<T> {
+  static description = 'QUIC Server is stopping';
+}
+
 class ErrorQUICConnection<T> extends ErrorQUIC<T> {
   static description = 'QUIC Connection error';
 }
@@ -306,6 +310,7 @@ export {
   ErrorQUICServerSocketNotRunning,
   ErrorQUICServerNewConnection,
   ErrorQUICServerInternal,
+  ErrorQUICServerStopping,
   ErrorQUICConnection,
   ErrorQUICConnectionStopping,
   ErrorQUICConnectionNotRunning,


### PR DESCRIPTION
[ci skip]

### Description

This PR addresses the issue where stopping a `QUICServer` with a starting `QUICConnection` will wait out the timeout of the connection without forcing it to stop. The solution to this is to provide `QUICServer` wide abort signal to be passed into `QUICConnection`s when they're being created. This abort signal has been modified with `setMaxListiners` to prevent warnings for more than 11 listeners since it's a 1 signal to many connections.

The `QUICClient` doesn't need the same treatment for two reasons. First, there is 1 connection per client. Second, it's not possible to stop the client without fully creating the client and connection first.

### Issues Fixed

- Fixes: #102 

### Tasks

- [X] 1. Abort starting connections when `quicServer.stop` is called with `force: true`.


### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
