### PR TITLE
optional servername via config

### DIFF
--- a/src/QUICClient.ts
+++ b/src/QUICClient.ts
@@ -186,7 +186,7 @@ class QUICClient {
       connection = new QUICConnection({
         type: 'client',
         scid,
-        serverName: host,
+        serverName: quicConfig.serverName || host,
         socket,
         remoteInfo: {
           host: host_,

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,11 @@ type QUICConfig = {
   verifyPeer: boolean;
 
   /**
+   * Optional explicit server name, defaults to host
+   */
+  serverName?: string;
+
+  /**
    * Custom TLS verification callback.
    * It is expected that the callback will throw an error if the verification
    * fails.
@@ -316,6 +321,7 @@ type QUICConfig = {
 type QUICClientConfigInput = Partial<QUICConfig>;
 
 type QUICServerConfigInput = Partial<QUICConfig> & {
+  serverName?: string;
   key: string | Array<string> | Uint8Array | Array<Uint8Array>;
   cert: string | Array<string> | Uint8Array | Array<Uint8Array>;
 };


### PR DESCRIPTION
### Description
Add possibility to provide servername via config.
This needs to be configurable for example in solana tpu transactions, where the servername has to be a specific string

### Issues Fixed
partial fix of:
https://github.com/MatrixAI/js-quic/issues/98#issuecomment-2156744139
