### PR TITLE
handle `EHOSTUNREACH` error and dispatch back to connection calling send

### DIFF
--- a/src/QUICClient.ts
+++ b/src/QUICClient.ts
@@ -513,6 +513,9 @@ class QUICClient {
         // Thrown due to invalid arguments on Win but also for network dropouts on all platforms
         // Falls through
         case 'ENETUNREACH':
+        // Thrown when no route to the host is available.
+        // Falls through
+        case 'EHOSTUNREACH':
           {
             this.dispatchEvent(
               new events.EventQUICClientErrorSend(

--- a/src/QUICServer.ts
+++ b/src/QUICServer.ts
@@ -207,6 +207,9 @@ class QUICServer {
         // Thrown due to invalid arguments on Win but also for network dropouts on all platforms
         // Falls through
         case 'ENETUNREACH':
+        // Thrown when no route to the host is available.
+        // Falls through
+        case 'EHOSTUNREACH':
           {
             this.dispatchEvent(
               new events.EventQUICClientErrorSend(


### PR DESCRIPTION
### Description

This PR addresses a problem where a send call for a IPv6 address that was unreachable caused the program to crash. This send error will be handled like other send errors that are specific problems with the connection. The error is dispatched back to the connection and thrown there.

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey-CLI/issues/219
* REF ENG-351

### Tasks

- [X] 1. Add `EHOSTUNREACH` to the errors that are dispatched back to the connection.
- [X] 2. This applies to client and server.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
