### PR TITLE
Adding `serverName` option to `CreateQUICClient`

### DIFF
--- a/src/QUICClient.ts
+++ b/src/QUICClient.ts
@@ -40,6 +40,7 @@ class QUICClient {
    * @param opts
    * @param opts.host - target host where wildcards are resolved to point locally.
    * @param opts.port - target port
+   * @param opts.serverName - The expected name of the server you are connecting to, defaults to host.
    * @param opts.localHost - defaults to `::` (dual-stack)
    * @param opts.localPort - defaults 0
    * @param opts.socket - optional shared QUICSocket
@@ -63,6 +64,7 @@ class QUICClient {
     opts: {
       host: string;
       port: number;
+      serverName?: string;
       localHost?: string;
       localPort?: number;
       crypto: QUICClientCrypto;
@@ -80,6 +82,7 @@ class QUICClient {
     opts: {
       host: string;
       port: number;
+      serverName?: string;
       socket: QUICSocket;
       crypto: QUICClientCrypto;
       config?: QUICClientConfigInput;
@@ -96,6 +99,7 @@ class QUICClient {
     {
       host,
       port,
+      serverName,
       localHost = '::',
       localPort = 0,
       socket,
@@ -110,6 +114,7 @@ class QUICClient {
     }: {
       host: string;
       port: number;
+      serverName?: string;
       localHost?: string;
       localPort?: number;
       socket?: QUICSocket;
@@ -186,7 +191,7 @@ class QUICClient {
       connection = new QUICConnection({
         type: 'client',
         scid,
-        serverName: host,
+        serverName: serverName ?? host,
         socket,
         remoteInfo: {
           host: host_,


### PR DESCRIPTION
### Description

This PR addresses adding a `serverName` option to `CreateQUICClient`. When a `QUICConnection` is established the server name is checked by the server and can reject the connection. We need the ability to set this separately from the `Host` in some scenarios.

### Issues Fixed
* Fixes #120
* Related #98

### Tasks
- [X] 1. Add `serverName` option to `CreateQUICClient`.

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
